### PR TITLE
Fix esc when too small

### DIFF
--- a/2048.h
+++ b/2048.h
@@ -59,7 +59,7 @@
 
 enum e_const
 {
-	WIN_VALUE = 4098
+	WIN_VALUE = 2048
 };
 
 typedef struct s_win {

--- a/visual_menu.c
+++ b/visual_menu.c
@@ -74,6 +74,5 @@ t_result get_grid_size(t_board *board)
 	board->size = (board->menu.scroll_offset == 0) ? 4 : 5;
 	wclear(board->menu.win);
 	wrefresh(board->menu.win);
-	window_size_check(board);
-	return SUCCESS;
+	return window_size_check(board);
 }


### PR DESCRIPTION
- capture ESC when the window gets too small after selecting 5x5